### PR TITLE
add  flag to go get test dependencies

### DIFF
--- a/stash_pullrequest.go
+++ b/stash_pullrequest.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/reconquest/executil-go"
 	"github.com/kovetskiy/stash"
+	"github.com/reconquest/executil-go"
 	"github.com/reconquest/hierr-go"
 	"github.com/seletskiy/tplutil"
 )
@@ -482,7 +482,7 @@ func (processor *ProcessorStashPullRequest) prepareSources(
 }
 
 func (processor *ProcessorStashPullRequest) goget() (string, error) {
-	return processor.spawn("go", "get", "-v", "-d")
+	return processor.spawn("go", "get", "-v", "-t", "-d")
 }
 
 func (processor *ProcessorStashPullRequest) gobuild() (string, error) {


### PR DESCRIPTION
if you use some testing utilities, tests fails with message like this:
```
# repo/path
client_test.go:10:2: cannot find package "github.com/stretchr/testify/assert" in any of:
	/usr/lib/go/src/github.com/stretchr/testify/assert (from $GOROOT)
	/tmp/uroboros_006395142/src/github.com/stretchr/testify/assert (from $GOPATH)
FAIL	repo/path [setup failed]

go test exited with non-zero exit code
```